### PR TITLE
Revert to old tools

### DIFF
--- a/static/js/apps/custom_dc/one/base/components/header_bar/menu.ts
+++ b/static/js/apps/custom_dc/one/base/components/header_bar/menu.ts
@@ -20,15 +20,15 @@ export const MenuItems: MenuSource[] = [
       },
       {
         title: "Scatter plots",
-        url: "/tools/visualization#visType=scatter",
+        url: "/tools/scatter",
       },
       {
         title: "Timelines",
-        url: "/tools/visualization#visType=timeline",
+        url: "/tools/timeline",
       },
       {
         title: "Map explorer",
-        url: "/tools/visualization#visType=map",
+        url: "/tools/map",
       },
       {
         title: "Data downloads",

--- a/static/js/apps/custom_dc/one/homepage/components/tools.tsx
+++ b/static/js/apps/custom_dc/one/homepage/components/tools.tsx
@@ -89,11 +89,8 @@ export const Tools = ({ primarySiteWebRoot }: ToolsProps): ReactElement => {
       </div>
 
       <p className="footer-text">
-        All data is pulled from{" "}
-        <a href="https://data.one.org" rel="noopener noreferrer">
-          official and credible sources
-        </a>{" "}
-        and updates regularly, so what you see will always be the latest.
+        Our regularly updated data comes from official and credible sources to
+        ensure you have access to the most current information available.
       </p>
     </div>
   );

--- a/static/js/apps/custom_dc/one/homepage/components/tools.tsx
+++ b/static/js/apps/custom_dc/one/homepage/components/tools.tsx
@@ -42,7 +42,7 @@ export const Tools = ({ primarySiteWebRoot }: ToolsProps): ReactElement => {
       </div>
 
       <div className="grid">
-        <a className="tool-card" href="tools/visualization#visType=scatter">
+        <a className="tool-card" href="tools/scatter">
           <div className="icon-wrapper">
             <figure>
               <ScatterPlot />
@@ -51,7 +51,7 @@ export const Tools = ({ primarySiteWebRoot }: ToolsProps): ReactElement => {
           <p className="tool-title">Scatter Plots</p>
         </a>
 
-        <a className="tool-card" href="tools/visualization#visType=timeline">
+        <a className="tool-card" href="tools/timeline">
           <div className="icon-wrapper">
             <figure>
               <Timeline />
@@ -60,7 +60,7 @@ export const Tools = ({ primarySiteWebRoot }: ToolsProps): ReactElement => {
           <p className="tool-title">Timelines</p>
         </a>
 
-        <a className="tool-card" href="tools/visualization#visType=map">
+        <a className="tool-card" href="tools/map">
           <div className="icon-wrapper">
             <figure>
               <TravelExplore />

--- a/static/js/tools/map/info.tsx
+++ b/static/js/tools/map/info.tsx
@@ -50,18 +50,18 @@ export function Info(): JSX.Element {
           </ol>
           {!_.isEmpty(window.infoConfig["map"]) && (
             <p>
-              Or you can start your exploration from these interesting points
-              ...
+              {/*Or you can start your exploration from these interesting points*/}
+              {/*...*/}
             </p>
           )}
 
-          <MemoizedInfoExamples configKey="map" />
+          {/*<MemoizedInfoExamples configKey="map" />*/}
 
-          <p>Take the data and use it on your site!</p>
-          <p>
-            <a href="mailto:collaborations@datacommons.org">Send</a> us your
-            discoveries!
-          </p>
+          {/*<p>Take the data and use it on your site!</p>*/}
+          {/*<p>*/}
+          {/*  <a href="mailto:collaborations@datacommons.org">Send</a> us your*/}
+          {/*  discoveries!*/}
+          {/*</p>*/}
           {footer && <div className="footer">* {footer}</div>}
         </div>
       )}

--- a/static/js/tools/map/info.tsx
+++ b/static/js/tools/map/info.tsx
@@ -18,7 +18,7 @@
  * Info page before a chart is shown.
  */
 
-import _ from "lodash";
+// import _ from "lodash";
 import React, { useContext } from "react";
 
 import { MemoizedInfoExamples } from "../shared/info_examples";
@@ -48,12 +48,12 @@ export function Info(): JSX.Element {
               hierarchy.
             </li>
           </ol>
-          {!_.isEmpty(window.infoConfig["map"]) && (
-            <p>
-              {/*Or you can start your exploration from these interesting points*/}
-              {/*...*/}
-            </p>
-          )}
+          {/*{!_.isEmpty(window.infoConfig["map"]) && (*/}
+          {/*  <p>*/}
+          {/*    Or you can start your exploration from these interesting points*/}
+          {/*    ...*/}
+          {/*  </p>*/}
+          {/*)}*/}
 
           {/*<MemoizedInfoExamples configKey="map" />*/}
 

--- a/static/js/tools/map/info.tsx
+++ b/static/js/tools/map/info.tsx
@@ -21,7 +21,7 @@
 // import _ from "lodash";
 import React, { useContext } from "react";
 
-import { MemoizedInfoExamples } from "../shared/info_examples";
+// import { MemoizedInfoExamples } from "../shared/info_examples";
 import { Context } from "./context";
 import { ifShowChart } from "./util";
 

--- a/static/js/tools/map/title.tsx
+++ b/static/js/tools/map/title.tsx
@@ -31,7 +31,7 @@ export function Title(): JSX.Element {
       {!ifShowChart(statVar.value, placeInfo.value) && (
         <div className="app-header">
           <h1 className="mb-4">Map Explorer</h1>
-          <a href="/tools/visualization#visType%3Dmap">
+          <a href="/tools/visualization#visType%3Dmap" style={{ display: "none" }}>
             Go back to the new Data Commons
           </a>
         </div>

--- a/static/js/tools/map/title.tsx
+++ b/static/js/tools/map/title.tsx
@@ -31,9 +31,9 @@ export function Title(): JSX.Element {
       {!ifShowChart(statVar.value, placeInfo.value) && (
         <div className="app-header">
           <h1 className="mb-4">Map Explorer</h1>
-          <a href="/tools/visualization#visType%3Dmap" style={{ display: "none" }}>
-            Go back to the new Data Commons
-          </a>
+          {/*<a href="/tools/visualization#visType%3Dmap">*/}
+          {/*  Go back to the new Data Commons*/}
+          {/*</a>*/}
         </div>
       )}
     </>

--- a/static/js/tools/scatter/app.tsx
+++ b/static/js/tools/scatter/app.tsx
@@ -63,9 +63,9 @@ function App(): JSX.Element {
             <Row>
               <div className="app-header">
                 <h1 className="mb-4">Scatter Plot Explorer</h1>
-                <a href="/tools/visualization#visType%3Dscatter" style={{ display: "none" }}>
-                  Go back to the new Data Commons
-                </a>
+                {/*<a href="/tools/visualization#visType%3Dscatter">*/}
+                {/*  Go back to the new Data Commons*/}
+                {/*</a>*/}
               </div>
             </Row>
           )}

--- a/static/js/tools/scatter/app.tsx
+++ b/static/js/tools/scatter/app.tsx
@@ -63,7 +63,7 @@ function App(): JSX.Element {
             <Row>
               <div className="app-header">
                 <h1 className="mb-4">Scatter Plot Explorer</h1>
-                <a href="/tools/visualization#visType%3Dscatter">
+                <a href="/tools/visualization#visType%3Dscatter" style={{ display: "none" }}>
                   Go back to the new Data Commons
                 </a>
               </div>

--- a/static/js/tools/scatter/info.tsx
+++ b/static/js/tools/scatter/info.tsx
@@ -43,17 +43,17 @@ function Info(): JSX.Element {
       </ol>
       {!_.isEmpty(window.infoConfig["scatter"]) && (
         <p>
-          Or you can start your exploration from these interesting points ...
+          {/*Or you can start your exploration from these interesting points ...*/}
         </p>
       )}
 
-      <MemoizedInfoExamples configKey="scatter" />
+      {/*<MemoizedInfoExamples configKey="scatter" />*/}
 
-      <p>Take the data and use it on your site!</p>
-      <p>
-        <a href="mailto:collaborations@datacommons.org">Send</a> us your
-        discoveries!
-      </p>
+      {/*<p>Take the data and use it on your site!</p>*/}
+      {/*<p>*/}
+      {/*  <a href="mailto:collaborations@datacommons.org">Send</a> us your*/}
+      {/*  discoveries!*/}
+      {/*</p>*/}
     </div>
   );
 }

--- a/static/js/tools/scatter/info.tsx
+++ b/static/js/tools/scatter/info.tsx
@@ -21,7 +21,7 @@
 // import _ from "lodash";
 import React from "react";
 
-import { MemoizedInfoExamples } from "../shared/info_examples";
+// import { MemoizedInfoExamples } from "../shared/info_examples";
 
 function Info(): JSX.Element {
   return (

--- a/static/js/tools/scatter/info.tsx
+++ b/static/js/tools/scatter/info.tsx
@@ -18,7 +18,7 @@
  * Info page before a chart is shown.
  */
 
-import _ from "lodash";
+// import _ from "lodash";
 import React from "react";
 
 import { MemoizedInfoExamples } from "../shared/info_examples";
@@ -41,11 +41,11 @@ function Info(): JSX.Element {
           hierarchy.
         </li>
       </ol>
-      {!_.isEmpty(window.infoConfig["scatter"]) && (
-        <p>
-          {/*Or you can start your exploration from these interesting points ...*/}
-        </p>
-      )}
+      {/*{!_.isEmpty(window.infoConfig["scatter"]) && (*/}
+      {/*  <p>*/}
+      {/*    Or you can start your exploration from these interesting points ...*/}
+      {/*  </p>*/}
+      {/*)}*/}
 
       {/*<MemoizedInfoExamples configKey="scatter" />*/}
 

--- a/static/js/tools/timeline/info.tsx
+++ b/static/js/tools/timeline/info.tsx
@@ -17,7 +17,7 @@
 // import _ from "lodash";
 import React, { Component } from "react";
 
-import { MemoizedInfoExamples } from "../shared/info_examples";
+// import { MemoizedInfoExamples } from "../shared/info_examples";
 
 class Info extends Component {
   render(): JSX.Element {

--- a/static/js/tools/timeline/info.tsx
+++ b/static/js/tools/timeline/info.tsx
@@ -32,17 +32,17 @@ class Info extends Component {
         </p>
         {!_.isEmpty(window.infoConfig["timeline"]) && (
           <p>
-            Or you can start your exploration from these interesting points ...
+            {/*Or you can start your exploration from these interesting points ...*/}
           </p>
         )}
 
-        <MemoizedInfoExamples configKey="timeline" />
+        {/*<MemoizedInfoExamples configKey="timeline" />*/}
 
-        <p>Take the data and use it on your site!</p>
-        <p>
-          <a href="mailto:collaborations@datacommons.org">Send</a> us your
-          discoveries!
-        </p>
+        {/*<p>Take the data and use it on your site!</p>*/}
+        {/*<p>*/}
+        {/*  <a href="mailto:collaborations@datacommons.org">Send</a> us your*/}
+        {/*  discoveries!*/}
+        {/*</p>*/}
       </div>
     );
   }

--- a/static/js/tools/timeline/info.tsx
+++ b/static/js/tools/timeline/info.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import _ from "lodash";
+// import _ from "lodash";
 import React, { Component } from "react";
 
 import { MemoizedInfoExamples } from "../shared/info_examples";
@@ -30,11 +30,11 @@ class Info extends Component {
           one or more statistical variables in the pane. There are thousands of
           statistical variables to choose from, arranged in a topical hierarchy.
         </p>
-        {!_.isEmpty(window.infoConfig["timeline"]) && (
-          <p>
-            {/*Or you can start your exploration from these interesting points ...*/}
-          </p>
-        )}
+        {/*{!_.isEmpty(window.infoConfig["timeline"]) && (*/}
+        {/*  <p>*/}
+        {/*    Or you can start your exploration from these interesting points ...*/}
+        {/*  </p>*/}
+        {/*)}*/}
 
         {/*<MemoizedInfoExamples configKey="timeline" />*/}
 

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -176,7 +176,7 @@ class Page extends Component<unknown, PageStateType> {
             {numPlaces === 0 && (
               <div className="app-header">
                 <h1 className="mb-4">Timelines Explorer</h1>
-                <a href="/tools/visualization#visType%3Dtimeline">
+                <a href="/tools/visualization#visType%3Dtimeline" style={{ display: "none"}}>
                   Go back to the new Data Commons
                 </a>
               </div>

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -176,9 +176,9 @@ class Page extends Component<unknown, PageStateType> {
             {numPlaces === 0 && (
               <div className="app-header">
                 <h1 className="mb-4">Timelines Explorer</h1>
-                <a href="/tools/visualization#visType%3Dtimeline" style={{ display: "none"}}>
-                  Go back to the new Data Commons
-                </a>
+                {/*<a href="/tools/visualization#visType%3Dtimeline">*/}
+                {/*  Go back to the new Data Commons*/}
+                {/*</a>*/}
               </div>
             )}
             <Card id="place-search">


### PR DESCRIPTION
The DC team will deprecate the "new" tools because their functionality is incomplete, and quite buggy with custom data.

This PR introduces fork-breaking changes:
- Hide the "Go back to new data commons" for all the tools
- Remove examples (since they are quite US centric) for all tools

It also
- changes the homepage and nav tools to point to the old tools.
- updates the text on data to match the data.one.org homepage