### PR TITLE
fix(server): reinstall ONE redirect dropped by the customdc_stable sync

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -352,6 +352,10 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
   register_routes_common(app)
   register_routes_base_dc(app)
 
+  if cfg.ENV == 'one':
+    from server.routes import redirects_one
+    redirects_one.install(app)
+
   if cfg.SHOW_DISASTER:
     register_routes_disasters(app)
 

--- a/server/tests/routes/redirects_one_test.py
+++ b/server/tests/routes/redirects_one_test.py
@@ -1,7 +1,10 @@
 import unittest
+from unittest import mock
 
 from flask import Flask
 
+from server.__init__ import create_app
+import server.lib.config as lib_config
 from server.routes import redirects_one
 
 
@@ -145,6 +148,29 @@ class TestRedirectsOne(unittest.TestCase):
       self.assertTrue(redirects_one.should_redirect(p), p)
     for p in passthroughs:
       self.assertFalse(redirects_one.should_redirect(p), p)
+
+
+class TestRedirectsOneWiring(unittest.TestCase):
+  """Guards the install() call in create_app, not just install() itself.
+
+  A customdc_stable sync once dropped the two-line wiring from
+  server/__init__.py while leaving redirects_one.py in place, orphaning the
+  redirect on prod. This test fails if create_app stops installing it under
+  the 'one' env.
+  """
+
+  def test_create_app_installs_redirect_for_one_env(self):
+    # get_config() returns the light test config; match the 'one' env so
+    # create_app takes the redirect branch. CUSTOM=True mirrors one.py and
+    # skips the GCS-backed load_redirects(), keeping the test offline.
+    cfg = lib_config.get_config()
+    cfg.ENV = 'one'
+    cfg.CUSTOM = True
+    with mock.patch.object(lib_config, 'get_config', return_value=cfg):
+      app = create_app()
+    resp = app.test_client().get('/', follow_redirects=False)
+    self.assertEqual(resp.status_code, 301)
+    self.assertEqual(resp.headers['Location'], 'https://data.one.org')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What happened

The June 2026 customdc_stable sync (PR #48, `bedfd9e4c`) removed the redirect wiring from `create_app`:

```python
if cfg.ENV == 'one':
  from server.routes import redirects_one
  redirects_one.install(app)
```

It left `server/routes/redirects_one.py` in place, so the redirect became orphaned dead code. Prod, rebuilt from the post-sync `one-dc-stable`, stopped redirecting to `data.one.org`. dc-staging still works because its image predates the sync.

The other two files from the original redirect PR (#45, `a36aae10d`) survived the sync byte-for-byte: `redirects_one.py` and its test. Only this four-line wiring was lost.

## Change

- Restore the wiring in `server/__init__.py`.
- Add `TestRedirectsOneWiring`: builds a real `create_app()` under `ENV=one` and asserts `/` 301s to `data.one.org`. The existing tests only exercised `install()` in isolation, so they could not catch the wiring being dropped. Verified it fails without the restore.

After merge, rebuild and redeploy the prod image so the running container picks this up.